### PR TITLE
Use main swift-snapshot repo.

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -3,9 +3,19 @@
     {
       "identity" : "swift-snapshot-testing",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/pimms/swift-snapshot-testing.git",
+      "location" : "https://github.com/pointfreeco/swift-snapshot-testing.git",
       "state" : {
-        "revision" : "b44b563e6ddc5a613a107fb57626047a7f1d4e1a"
+        "revision" : "59b663f68e69f27a87b45de48cb63264b8194605",
+        "version" : "1.15.1"
+      }
+    },
+    {
+      "identity" : "swift-syntax",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-syntax.git",
+      "state" : {
+        "revision" : "6ad4ea24b01559dde0773e3d091f1b9e36175036",
+        "version" : "509.0.2"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
         .library(name: "DemoKitSnapshot", targets: ["DemoKitSnapshot"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/pimms/swift-snapshot-testing.git", exact: "1.9.666"),
+        .package(url: "https://github.com/pointfreeco/swift-snapshot-testing.git", exact: "1.15.1"),
     ],
     targets: [
         .target(name: "DemoKit"),

--- a/Sources/DemoKitSnapshot/XCTestCase+Extensions.swift
+++ b/Sources/DemoKitSnapshot/XCTestCase+Extensions.swift
@@ -143,7 +143,6 @@ extension XCTestCase {
         line: UInt
     ) {
         UIView.setAnimationsEnabled(false)
-        let subpixelThreshold: UInt8 = 5
         let userInterfaceStyle: [UIUserInterfaceStyle] = [.light, .dark]
 
         userInterfaceStyle.forEach { userInterfaceStyle in
@@ -159,7 +158,7 @@ extension XCTestCase {
                     matching: viewController,
                     as: .image(
                         on: device.imageConfig,
-                        subpixelThreshold: subpixelThreshold,
+                        perceptualPrecision: 0.98,
                         traits: traits
                     ),
                     named: name,


### PR DESCRIPTION
The fork isn't necessary anymore as the main repo has been updated with a perceptual precision parameter for the diff.