### PR TITLE
Tweak default snapshot precision to 0.997

### DIFF
--- a/Sources/DemoKitSnapshot/XCTestCase+Extensions.swift
+++ b/Sources/DemoKitSnapshot/XCTestCase+Extensions.swift
@@ -36,7 +36,7 @@ extension XCTestCase {
         record: Bool = false,
         // https://github.com/pointfreeco/swift-snapshot-testing/pull/628#issuecomment-1256363278
         precision: Float = 1,
-        perceptualPrecision: Float = 0.95,
+        perceptualPrecision: Float = 0.9,
         file: StaticString = #file,
         line: UInt = #line
     ) {
@@ -153,7 +153,7 @@ extension XCTestCase {
         testName: String,
         tweakName: String? = nil,
         precision: Float = 1,
-        perceptualPrecision: Float = 0.95,
+        perceptualPrecision: Float = 0.9,
         file: StaticString,
         line: UInt
     ) {

--- a/Sources/DemoKitSnapshot/XCTestCase+Extensions.swift
+++ b/Sources/DemoKitSnapshot/XCTestCase+Extensions.swift
@@ -35,7 +35,7 @@ extension XCTestCase {
         demoable: any Demoable,
         record: Bool = false,
         // https://github.com/pointfreeco/swift-snapshot-testing/pull/628#issuecomment-1256363278
-        precision: Float = 0.98,
+        precision: Float = 0.997,
         perceptualPrecision: Float = 0.98,
         file: StaticString = #file,
         line: UInt = #line
@@ -152,7 +152,7 @@ extension XCTestCase {
         record: Bool,
         testName: String,
         tweakName: String? = nil,
-        precision: Float = 0.98,
+        precision: Float = 0.997,
         perceptualPrecision: Float = 0.98,
         file: StaticString,
         line: UInt

--- a/Sources/DemoKitSnapshot/XCTestCase+Extensions.swift
+++ b/Sources/DemoKitSnapshot/XCTestCase+Extensions.swift
@@ -35,7 +35,7 @@ extension XCTestCase {
         demoable: any Demoable,
         record: Bool = false,
         // https://github.com/pointfreeco/swift-snapshot-testing/pull/628#issuecomment-1256363278
-        precision: Float = 0.997,
+        precision: Float = 1,
         perceptualPrecision: Float = 0.98,
         file: StaticString = #file,
         line: UInt = #line
@@ -152,7 +152,7 @@ extension XCTestCase {
         record: Bool,
         testName: String,
         tweakName: String? = nil,
-        precision: Float = 0.997,
+        precision: Float = 1,
         perceptualPrecision: Float = 0.98,
         file: StaticString,
         line: UInt

--- a/Sources/DemoKitSnapshot/XCTestCase+Extensions.swift
+++ b/Sources/DemoKitSnapshot/XCTestCase+Extensions.swift
@@ -36,7 +36,7 @@ extension XCTestCase {
         record: Bool = false,
         // https://github.com/pointfreeco/swift-snapshot-testing/pull/628#issuecomment-1256363278
         precision: Float = 1,
-        perceptualPrecision: Float = 0.98,
+        perceptualPrecision: Float = 0.95,
         file: StaticString = #file,
         line: UInt = #line
     ) {
@@ -153,7 +153,7 @@ extension XCTestCase {
         testName: String,
         tweakName: String? = nil,
         precision: Float = 1,
-        perceptualPrecision: Float = 0.98,
+        perceptualPrecision: Float = 0.95,
         file: StaticString,
         line: UInt
     ) {


### PR DESCRIPTION
In [this FinniversKit PR](https://github.com/finn-no/FinniversKit/pull/1313), I noticed the current snapshot precision does not catch changes on small components in a snapshot, like ribbons. 

I did some testing and tweaking and figured the lowest precision we can have to catch changes like these is 0.997. This precision will still make all other snapshots in FinniversKit pass (except for a few special cases where we have a very low precision already).

Since we do want to capture such changes by default, I'll update the precision in this PR. If any other packages using DemoKit will not pass with this precision, there's an option to pass in a custom one.

I did not have time to learn more about `precision` and `perceptualPrecision` and which one is best to tweak. But this is still better than what we had.