### PR TITLE
Fix: Replace deprecated method

### DIFF
--- a/Sources/DemoKitSnapshot/XCTestCase+Extensions.swift
+++ b/Sources/DemoKitSnapshot/XCTestCase+Extensions.swift
@@ -43,12 +43,12 @@ extension XCTestCase {
         guard demoable.shouldSnapshotTest else { return }
 
         let viewController = ViewControllerMapper.viewController(for: demoable)
-        viewController.view.layoutIfNeeded()
 
         if let tweakableDemo = demoable as? TweakableDemo, tweakableDemo.shouldSnapshotTweaks, tweakableDemo.numberOfTweaks > 0 {
             for tweakIndex in (0..<tweakableDemo.numberOfTweaks) {
                 let tweak = tweakableDemo.tweak(for: tweakIndex)
                 tweakableDemo.configure(forTweakAt: tweakIndex)
+                viewController.view.layoutIfNeeded()
 
                 performSnapshots(
                     viewController: viewController,
@@ -62,6 +62,8 @@ extension XCTestCase {
                 )
             }
         } else {
+            viewController.view.layoutIfNeeded()
+
             performSnapshots(
                 viewController: viewController,
                 record: record,

--- a/Sources/DemoKitSnapshot/XCTestCase+Extensions.swift
+++ b/Sources/DemoKitSnapshot/XCTestCase+Extensions.swift
@@ -170,7 +170,7 @@ extension XCTestCase {
                 ])
 
                 assertSnapshot(
-                    matching: viewController,
+                    of: viewController,
                     as: .image(
                         on: device.imageConfig,
                         precision: precision,


### PR DESCRIPTION
# Why?
In my FinniversKit PR I had some failing snapshot tests. After a lot of digging I found the culprit: the method used to perform snapshot testing.

[`assertSnapshot(matching:as:named:record:timeout:file:testName:line:)`](https://github.com/pointfreeco/swift-snapshot-testing/blob/6a77fc240dce4afb31e22593e2bc9eefc174d30d/Sources/SnapshotTesting/Internal/Deprecations.swift#L326) is deprecated and replaced by [`assertSnapshot(of:as:named:record:timeout:file:testName:line:)`](https://github.com/pointfreeco/swift-snapshot-testing/blob/6a77fc240dce4afb31e22593e2bc9eefc174d30d/Sources/SnapshotTesting/AssertSnapshot.swift#L102).

# What?
- Replace deprecated method.
- Call `layoutIfNeeded()` after configuring each tweak.

# Version change
Patch.